### PR TITLE
Support setting render pass

### DIFF
--- a/Runtime/Scripts/FPVolumetricFog.cs
+++ b/Runtime/Scripts/FPVolumetricFog.cs
@@ -15,8 +15,12 @@ namespace UniversalForwardPlusVolumetric
 
         public override void Create()
         {
-            m_GenerateMaxZPass = new GenerateMaxZPass(config.renderPassEvent);
-            m_VolumetricLightingPass = new FPVolumetricLightingPass(config.renderPassEvent);
+            var renderPass = config != null
+                ? config.renderPassEvent
+                : RenderPassEvent.BeforeRenderingPostProcessing;
+
+            m_GenerateMaxZPass = new GenerateMaxZPass(renderPass);
+            m_VolumetricLightingPass = new FPVolumetricLightingPass(renderPass);
         }
 
         public override void AddRenderPasses(ScriptableRenderer renderer, ref RenderingData renderingData)

--- a/Runtime/Scripts/FPVolumetricFog.cs
+++ b/Runtime/Scripts/FPVolumetricFog.cs
@@ -15,10 +15,10 @@ namespace UniversalForwardPlusVolumetric
 
         public override void Create()
         {
-            m_GenerateMaxZPass = new GenerateMaxZPass();
-            m_VolumetricLightingPass = new FPVolumetricLightingPass();
+            m_GenerateMaxZPass = new GenerateMaxZPass(config.renderPassEvent);
+            m_VolumetricLightingPass = new FPVolumetricLightingPass(config.renderPassEvent);
         }
-        
+
         public override void AddRenderPasses(ScriptableRenderer renderer, ref RenderingData renderingData)
         {
             if (config == null || !config.enabled)

--- a/Runtime/Scripts/GenerateMaxZPass.cs
+++ b/Runtime/Scripts/GenerateMaxZPass.cs
@@ -17,9 +17,9 @@ namespace UniversalForwardPlusVolumetric
         private VBufferParameters m_VBufferParameters;
         private ProfilingSampler m_ProfilingSampler;
 
-        public GenerateMaxZPass()
+        public GenerateMaxZPass(RenderPassEvent renderPassEvent)
         {
-            renderPassEvent = RenderPassEvent.BeforeRenderingPostProcessing;
+            this.renderPassEvent = renderPassEvent;
             m_PassData = new GenerateMaxZMaskPassData();
         }
 
@@ -44,7 +44,7 @@ namespace UniversalForwardPlusVolumetric
         {
             if (m_PassData.generateMaxZCS == null)
                 return;
-            
+
             CoreUtils.SetKeyword(m_PassData.generateMaxZCS, "PLANAR_OBLIQUE_DEPTH", false);
 
             m_PassData.maxZKernel = m_PassData.generateMaxZCS.FindKernel("ComputeMaxZ");
@@ -55,7 +55,7 @@ namespace UniversalForwardPlusVolumetric
             Vector2Int intermediateMaskSize = new Vector2Int();
             Vector2Int finalMaskSize = new Vector2Int();
             Vector2Int targetSize = new Vector2Int((int)(camera.scaledPixelWidth * renderingData.cameraData.renderScale), (int)(camera.scaledPixelHeight * renderingData.cameraData.renderScale));
-            
+
             intermediateMaskSize.x = VolumetricUtils.DivRoundUp(targetSize.x, 8);
             intermediateMaskSize.y = VolumetricUtils.DivRoundUp(targetSize.y, 8);
             finalMaskSize.x = intermediateMaskSize.x / 2;
@@ -74,12 +74,12 @@ namespace UniversalForwardPlusVolumetric
             desc.dimension = TextureDimension.Tex2D;
             desc.useDynamicScale = true;
             desc.enableRandomWrite = true;
-            RenderingUtils.ReAllocateIfNeeded(ref m_MaxZ8xBufferHandle, desc, FilterMode.Bilinear, name:"MaxZ mask 8x");
-            RenderingUtils.ReAllocateIfNeeded(ref m_MaxZBufferHandle, desc, FilterMode.Bilinear, name:"MaxZ mask");
+            RenderingUtils.ReAllocateIfNeeded(ref m_MaxZ8xBufferHandle, desc, FilterMode.Bilinear, name: "MaxZ mask 8x");
+            RenderingUtils.ReAllocateIfNeeded(ref m_MaxZBufferHandle, desc, FilterMode.Bilinear, name: "MaxZ mask");
 
             desc.width = Mathf.CeilToInt(targetSize.x / 16.0f);
             desc.height = Mathf.CeilToInt(targetSize.y / 16.0f);
-            RenderingUtils.ReAllocateIfNeeded(ref m_DilatedMaxZBufferHandle, desc, FilterMode.Bilinear, name:"Dilated MaxZ mask");
+            RenderingUtils.ReAllocateIfNeeded(ref m_DilatedMaxZBufferHandle, desc, FilterMode.Bilinear, name: "Dilated MaxZ mask");
         }
 
 #if UNITY_6000_0_OR_NEWER

--- a/Runtime/Scripts/VolumetricConfig.cs
+++ b/Runtime/Scripts/VolumetricConfig.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Rendering.Universal;
 
 namespace UniversalForwardPlusVolumetric
 {
@@ -79,7 +80,7 @@ namespace UniversalForwardPlusVolumetric
         public DenoiseMode denoiseMode = DenoiseMode.Both;
         public bool filterVolume => (denoiseMode == DenoiseMode.Gaussian || denoiseMode == DenoiseMode.Both);
         public bool enableReprojection => (denoiseMode == DenoiseMode.Reprojection || denoiseMode == DenoiseMode.Both);
-        
+
         [Header("Volumetric Lighting - Advanced")]
         [Range(0.001f, 1f)]
         public float sampleOffsetWeight = 1f;
@@ -91,5 +92,9 @@ namespace UniversalForwardPlusVolumetric
 
         [Tooltip("Controls the history weight. Lower values reduce the afterimage effect but also decrease the smoothness of light blending. The default value is 7.")]
         [Range(1, 7)] public int blendWeight = 7;
+
+        [Tooltip("Which render pass to render at. The default is BeforeRenderingPostProcessing")]
+        public RenderPassEvent renderPassEvent = RenderPassEvent.BeforeRenderingPostProcessing;
+
     }
 }


### PR DESCRIPTION
This allows users to set the Render Pass Event to use, instead of always hardcoding it as "After rendering post processing". This is useful, for example, to change it to "Before Rendering Transparents" so that it won't show above Screen Space - Camera UI canvases.

My code editor did some auto formatting, happy to remove that to keep it cleaner if you'd like, just let me know.